### PR TITLE
add reagent/create-class

### DIFF
--- a/script/nbb_tests.clj
+++ b/script/nbb_tests.clj
@@ -57,7 +57,8 @@
   (testing "react is loaded first, then reagent"
     (nbb {:out :inherit} "test-scripts/react-test/ink-test.cljs"))
   (testing "reagent is loaded first, then react"
-    (nbb {:out :inherit} "test-scripts/react-test/ink-test2.cljs")))
+    (nbb {:out :inherit} "test-scripts/react-test/ink-test2.cljs"))
+  (is (= "<div data-reactroot=\"\"><p>Hi</p></div>" (nbb "test-scripts/react-test/create-class-test.cljs"))))
 
 (deftest esm-libs-test
   (tasks/shell {:dir "test-scripts/esm-test"} (npm "install"))

--- a/src/nbb/reagent.cljs
+++ b/src/nbb/reagent.cljs
@@ -62,11 +62,15 @@
 
 (def rns (sci/create-ns 'reagent.core nil))
 
+(defn r-create-class [spec]
+  (reagent.core/create-class spec))
+
 (def reagent-namespace
   {'atom (sci/copy-var r/atom rns)
    'as-element (sci/copy-var r/as-element rns)
    'with-let (sci/copy-var with-let rns)
-   'cursor (sci/copy-var r/cursor rns)})
+   'cursor (sci/copy-var r/cursor rns)
+   'create-class (sci/copy-var r-create-class rns)})
 
 (def rtmns (sci/create-ns 'reagent.ratom nil))
 

--- a/test-scripts/react-test/create-class-test.cljs
+++ b/test-scripts/react-test/create-class-test.cljs
@@ -1,0 +1,17 @@
+(ns create-react-class-test
+  (:require [reagent.core :as r]
+            [reagent.dom.server :as srv]))
+
+(defn err-boundary
+  [& _children]
+  (let [err-state (r/atom nil)]
+    (r/create-class
+      {:component-did-catch (fn [err info]
+                              (reset! err-state [err info]))
+       :reagent-render (fn [& children]
+                         (if (nil? @err-state)
+                           (into [:<>] children)
+                           (let [[_ info] @err-state]
+                             [:p "Oops! Something bad happened : " info])))})))
+
+(prn (srv/render-to-string (r/as-element [:div [err-boundary [:p "Hi"]]])))


### PR DESCRIPTION
This pull request adds support to reagent's [create-class](http://reagent-project.github.io/docs/master/reagent.core.html#var-create-class). I decided to only include the 1-arity version of this function since nbb has no support for `reagent/create-compiler` as of now.

`create-class` can be useful for defining components such as error boundaries, as seen in [this post](https://lilac.town/writing/modern-react-in-cljs-error-boundaries/) by lilactown