### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Doing stuff which takes a while
 3
 ```
 
-Also see [API docs](api.md).
+Also see [API docs](doc/api.md#promesa).
 
 ### REPL
 


### PR DESCRIPTION
One of the references to the API docs was missing a sub-directory.