### PR TITLE
docs: Fix GitHub Discussions link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Additional goals and features are:
 ## Community
 
 - Submit bugs at [Github Issues](https://github.com/borkdude/nbb/issues).
-- Join [Github Discussions](https://github.com/borkdude/nbb/discussions/categories) for proposing ideas, show and tell and Q&A.
+- Join [Github Discussions](https://github.com/borkdude/nbb/discussions) for proposing ideas, show and tell and Q&A.
 -  Join the [channel](https://app.slack.com/client/T03RZGPFR/C029PTWD3HR) on Clojurians Slack.
 - Follow news or tweet using the Twitter hashtag
   [#nbbjs](https://twitter.com/hashtag/nbbjs?f=live).


### PR DESCRIPTION
Fixes the "Github Discussions" link under "Community" in the `README`. Changes it from https://github.com/borkdude/nbb/discussions/categories, which `404`s, to https://github.com/borkdude/nbb/discussions.