### PR TITLE
Example: synchronous SQLite using better-sqlite3

### DIFF
--- a/examples/sqlite-sync/README.md
+++ b/examples/sqlite-sync/README.md
@@ -1,0 +1,29 @@
+# Synchronous sqlite3 example using `better-sqlite3`
+
+While [node-sqlite3](https://github.com/mapbox/node-sqlite3) is asynchronous and non-blocking,
+[better-sqlite3](https://github.com/JoshuaWise/better-sqlite3) provides a synchronous API - which may be simpler and
+faster for many typical SQLite use cases.
+
+
+# Installation
+
+Install `better-sqlite3` by running `npm install`.
+
+# example.cljs
+
+A `better-sqlite3`-based version of `examples/sqlite/example.cljs`.
+
+```
+$ nbb example.cljs
+1: 0
+2: 1
+3: 2
+4: 3
+5: 4
+6: 5
+7: 6
+8: 7
+9: 8
+10: 9
+```
+

--- a/examples/sqlite-sync/example.cljs
+++ b/examples/sqlite-sync/example.cljs
@@ -1,0 +1,12 @@
+(ns example
+  (:require
+    ["better-sqlite3$default" :as sqlite]))
+
+(let [db (new sqlite ":memory:")
+      _  (-> db (.prepare "CREATE TABLE lorem (info TEXT)") .run)
+      stmt (.prepare db "INSERT INTO lorem VALUES (?)")]
+  (doall (map #(.run stmt (str %)) (range 10)))
+  (doall (map #(println (str (.-id %) ": " (.-info %)))
+              (-> db (.prepare "SELECT rowid AS id, info FROM lorem") .all)))
+  (.close db))
+

--- a/examples/sqlite-sync/package.json
+++ b/examples/sqlite-sync/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "better-sqlite3": "^7.4.6"
+  }
+}
+


### PR DESCRIPTION
A port of 
  examples/sqlite/example.cljs
from sqlite/sqlite3 to better-sqlite3 
