### PR TITLE
[FIX] (macros): ignore :require-macros as nbb has first class support of macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## 0.3.x
+
+- Fix [#154](https://github.com/babashka/nbb/issues/154): require-macros trigger an error
+
 ## 0.3.1
 
 - Fix [#139](https://github.com/babashka/nbb/issues/139): include `goog.string/format`

--- a/src/nbb/core.cljs
+++ b/src/nbb/core.cljs
@@ -246,9 +246,13 @@
   ;; the parsing is still very crude, we only support a subset of the ns form
   ;; and ignore everything but (:require clauses)
   (let [[_ns ns-name & ns-forms] ns-form
+        ignored (group-by (fn [ns-form]
+                             (and (seq? ns-form)
+                                  (= :require-macros (first ns-form)))) ns-forms)
+        
         grouped (group-by (fn [ns-form]
                             (and (seq? ns-form)
-                                 (= :require (first ns-form)))) ns-forms)
+                                 (= :require (first ns-form)))) (get ignored false))
         require-forms (get grouped true)
         other-forms (get grouped false)
         ns-obj (sci/eval-form @sci-ctx (list 'do (list* 'ns ns-name other-forms) '*ns*))

--- a/test-scripts/ignore_require_macros.cljc
+++ b/test-scripts/ignore_require_macros.cljc
@@ -1,0 +1,13 @@
+(ns ignore-require-macros
+  (:require-macros ignore-require-macros))
+
+(defmacro add
+  [a b]
+  `(+ ~a ~b))
+
+(defn subtract
+  [a b]
+  (- a b))
+
+{:add (add 2 3)
+ :subtract (subtract 3 2)}

--- a/test/nbb/main_test.cljs
+++ b/test/nbb/main_test.cljs
@@ -214,5 +214,10 @@
       (.then (fn [val]
                (is (true? val))))))
 
+(deftest-async ignore-require-macros-test
+  (-> (main-with-args ["test-scripts/ignore_require_macros.cljc"])
+      (.then (fn [res]
+               (is (= {:add 5 :subtract 1} res))))))
+
 (defn init []
   (t/run-tests 'nbb.main-test 'nbb.test-test))


### PR DESCRIPTION
Fix [#154](https://github.com/babashka/nbb/issues/154)

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
