### PR TITLE
Add tinyhttp example

### DIFF
--- a/examples/tinyhttp/example.cljs
+++ b/examples/tinyhttp/example.cljs
@@ -1,0 +1,22 @@
+;; This script demonstrates use of tinyhttp with a logging middleware
+(ns example
+  (:require ["@tinyhttp/app" :as app]
+            ["@tinyhttp/logger" :as logger]))
+
+(def app (app/App.))
+
+(-> app
+    (.use (logger/logger))
+    (.get "/" (fn [_req res]
+                (.send res "<h1>Hello world</h1>")))
+    (.get "/page/:page/" (fn [req res]
+                           (-> res 
+                             (.status 200)
+                             (.send 
+                              (apply str [(str "<h1>" "What a cool page" "</h1>")
+                                          (str "<h2>Path</h2>")
+                                          (str "<pre>" (.-path req) "</pre>")
+                                          (str "<h2>Params</h2>")
+                                          (str "<pre>" (js/JSON.stringify (.-params req) nil 2) "</pre>")])
+                                    ))))
+    (.listen 3000 (fn [] (js/console.log "Listening on http://localhost:3000"))))

--- a/examples/tinyhttp/package.json
+++ b/examples/tinyhttp/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@tinyhttp/app": "^2.0.19",
+    "@tinyhttp/logger": "^1.3.0"
+  }
+}


### PR DESCRIPTION
This example demonstrates use of `tinyhttp` (an alternative to express) and simple use of middleware.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).