### PR TITLE
Add datascript tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ example.pdf
 */**/package-lock.json
 print-cli-args/print-cli-args
 clojure_logo.png
+test-scripts/feature-tests/libraries/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## 0.3.7
+
+- Add optional datascript tests
+
 ## 0.3.6
 
 - Allow `reagent.ratom` to be required separately

--- a/bb.edn
+++ b/bb.edn
@@ -47,7 +47,7 @@
          (println "Run node lib/nbb_main.js to test nbb")
          (println "Run bb run-tests to run the tests")
          (apply clojure (wrap-cmd "-M -m shadow.cljs.devtools.cli --force-spawn watch modules")
-                *command-line-args*))}
+           *command-line-args*))}
 
   run-tests (shell "node lib/nbb_tests.js")
 
@@ -55,21 +55,23 @@
            :doc "Compiles release build."
            :task
            (do (apply clojure (wrap-cmd "-M -m shadow.cljs.devtools.cli --force-spawn release modules")
-                      *command-line-args*)
-               (spit "lib/nbb_core.js"
-                     (clojure.string/replace (slurp "lib/nbb_core.js") (re-pattern "self") "globalThis"))
-               (spit "lib/nbb_main.js"
-                     (str "#!/usr/bin/env node\n\n" (slurp "lib/nbb_main.js")))
-               (shell "chmod +x lib/nbb_main.js")
-               (run! fs/delete (fs/glob "lib" "**.map")))}
+                 *command-line-args*)
+             (spit "lib/nbb_core.js"
+                   (clojure.string/replace (slurp "lib/nbb_core.js") (re-pattern "self") "globalThis"))
+             (spit "lib/nbb_main.js"
+                   (str "#!/usr/bin/env node\n\n" (slurp "lib/nbb_main.js")))
+             (shell "chmod +x lib/nbb_main.js")
+             (run! fs/delete (fs/glob "lib" "**.map")))}
 
   run-integration-tests nbb-tests/main
+
+  run-feature-integration-tests nbb-feature-tests/main
 
   publish {:doc "Bumps version, pushes tag and lets CI publish to npm."
            :task
            (do (shell "npm version patch")
-               (shell "git push --atomic origin main"
-                      (str "v" (:version (json/parse-string (slurp "package.json") true)))))}
+             (shell "git push --atomic origin main"
+                    (str "v" (:version (json/parse-string (slurp "package.json") true)))))}
 
   current-tag (->> (shell {:out :string} "git describe")
                    :out
@@ -88,13 +90,15 @@
                    (run 'clean)
                    (run 'release)
                    (run 'run-tests)
-                   (run 'run-integration-tests))}
+                   (run 'run-integration-tests)
+                   (when features
+                     (run 'run-feature-integration-tests)))}
   ci:publish {:doc "Publishes release build to npm"
               :depends [ci:is-release]
               :task
               (if ci:is-release
                 (do (println "Releasing")
-                    (binding [*test* false]
-                      (run 'release)
-                      (shell "npm publish")))
+                  (binding [*test* false]
+                    (run 'release)
+                    (shell "npm publish")))
                 (println "Skipping release."))}}}

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -51,7 +51,11 @@ To run tests, run `bb run-tests` for unit tests and `bb run-integration-tests` f
 
 ## Features
 
-`nbb` can optionally bundle additional Clojure(Script) libraries as features. These can be specified with `$NBB_FEATURES` to compilation tasks e.g. `NBB_FEATURES=datascript,datascript-transit bb release`. The following features are provided:
+`nbb` optionally bundles additional Clojure(Script) libraries as features.
+Features are designed to be kept isolated from nbb's core and are enabled with
+an optional `$NBB_FEATURES` variable. `$NBB_FEATURES` is used by compilation
+tasks e.g. `NBB_FEATURES=datascript,datascript-transit bb release`. The
+following features are available:
 
 * [datascript](https://github.com/tonsky/datascript)
 * [datascript-transit](https://github.com/tonsky/datascript-transit)
@@ -61,3 +65,7 @@ To add a new feature, add the following under `features/$LIBRARY/`:
 - `shadow-cljs.edn` - Compiler options to build library in advanced/release mode
 - `src/nbb/impl/$LIBRARY.cljs` - Sci mappings
 - `src/nbb_features.edn` - Configuration to map namespaces to js assets
+
+Some features have tests under `test-scripts/feature-tests`. These tests are run
+the same as integration tests but with `$NBB_FEATURES` e.g.
+`NBB_FEATURES=datascript bb ci:test`.

--- a/script/nbb_feature_tests.clj
+++ b/script/nbb_feature_tests.clj
@@ -1,0 +1,24 @@
+(ns nbb-feature-tests
+  "Test runner for feature tests"
+  (:require [babashka.tasks :as tasks]
+            [clojure.string :as str]
+            [babashka.fs :as fs]))
+
+(defn datascript-tests
+  []
+  (let [feature-dir "test-scripts/feature-tests/libraries/datascript"]
+    (when-not (fs/exists? feature-dir)
+      (tasks/shell "git clone -b 1.3.12 https://github.com/tonsky/datascript" feature-dir)
+      (fs/copy "test-scripts/feature-tests/datascript_test_core.cljs"
+               (str feature-dir "/test/datascript/test/core.cljc")
+               {:replace-existing true}))
+    (tasks/shell "node lib/nbb_main.js -cp"
+                 (str feature-dir "/test")
+                 "test-scripts/feature-tests/datascript_test_runner.cljs")))
+
+(defn main []
+  (let [features (some-> (System/getenv "NBB_FEATURES")
+                         (str/split (re-pattern ","))
+                         set)]
+    (when (features "datascript")
+      (datascript-tests))))

--- a/test-scripts/feature-tests/datascript_test_core.cljs
+++ b/test-scripts/feature-tests/datascript_test_core.cljs
@@ -1,0 +1,19 @@
+(ns datascript.test.core
+  "This is a minimal version of datascript.tests.core that works with nbb tests"
+  (:require [cljs.test :as t]
+            [datascript.core :as d]))
+
+(defmethod t/assert-expr 'thrown-msg? [menv msg form]
+  (let [[_ match & body] form]
+    `(try
+       ~@body
+       (t/do-report {:type :fail, :message ~msg, :expected '~form, :actual nil})
+       (catch :default e#
+         (let [m# (.-message e#)]
+           (if (= ~match m#)
+             (t/do-report {:type :pass, :message ~msg, :expected '~form, :actual e#})
+             (t/do-report {:type :fail, :message ~msg, :expected '~form, :actual e#}))
+           e#)))))
+
+(defn all-datoms [db]
+  (into #{} (map (juxt :e :a :v)) (d/datoms db :eavt)))

--- a/test-scripts/feature-tests/datascript_test_core.cljs
+++ b/test-scripts/feature-tests/datascript_test_core.cljs
@@ -1,5 +1,5 @@
 (ns datascript.test.core
-  "This is a minimal version of datascript.tests.core that works with nbb tests"
+  "This is a minimal version of datascript.test.core that works with nbb tests"
   (:require [cljs.test :as t]
             [datascript.core :as d]))
 

--- a/test-scripts/feature-tests/datascript_test_runner.cljs
+++ b/test-scripts/feature-tests/datascript_test_runner.cljs
@@ -1,0 +1,40 @@
+(ns test-runner
+  (:require [cljs.test :as t]
+            [nbb.core :as nbb]
+            [datascript.test.query]
+            [datascript.test.pull-api]
+            [datascript.test.query-rules]
+            [datascript.test.conn]
+            [datascript.test.explode]
+            [datascript.test.filter]
+            [datascript.test.ident]
+            [datascript.test.query-fns]
+            [datascript.test.query-not]
+            [datascript.test.query-or]
+            [datascript.test.query-aggregates]
+            [datascript.test.query-pull]
+            [datascript.test.query-return-map]
+            [datascript.test.tuples]
+            [datascript.test.query-find-specs]
+            [datascript.test.transact]))
+
+(defn init []
+  (t/run-tests 'datascript.test.query
+               'datascript.test.pull-api
+               'datascript.test.query-rules
+               'datascript.test.conn
+               'datascript.test.explode
+               'datascript.test.filter
+               'datascript.test.ident
+               'datascript.test.query-fns
+               'datascript.test.tuples
+               'datascript.test.transact
+               'datascript.test.query-pull
+               'datascript.test.query-find-specs
+               'datascript.test.query-return-map
+               'datascript.test.query-not
+               'datascript.test.query-aggregates
+               'datascript.test.query-or))
+
+(when (= nbb/*file* (:file (meta #'init)))
+  (init))


### PR DESCRIPTION
Hi. Added some datascript tests that can be enabled optionally in CI with `$NBB_FEATURES`. [Example CI job that passes](https://app.circleci.com/pipelines/github/logseq-cldwalker/nbb/2/workflows/78c34c22-59cf-4445-830c-c12867804c8c/jobs/2?invite=true#step-105-505). Once there are more features, it'd be nice to make this more data driven like bb's library tests

---
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
