### PR TITLE
Add PouchDB example

### DIFF
--- a/examples/pouchdb/example.cljs
+++ b/examples/pouchdb/example.cljs
@@ -1,0 +1,45 @@
+(ns example
+  (:require ["PouchDB$default" :as pouch]
+            [promesa.core :as p]
+            [cljs-bean.core :refer [->clj ->js]]))
+
+;; PouchDB intro: https://pouchdb.com/learn.html
+
+;; PouchDB helper functions
+(defn pouch-put [db doc]
+  (.put db (->js doc)))
+
+(defn pouch-get [db id]
+  (p/let [doc-js (.get db id)]
+    (->clj doc-js)))
+
+(defn pouch-rm [db doc]
+  (.remove db (->js doc)))
+
+;; Create a DB if not exist
+(def db (pouch. "kittens"))
+
+(def mittens
+  {:_id "mittens"
+   :name "Mittens"
+   :occupation :kitten
+   :age 4
+   :hobbies ["playing with balls of yarn"
+             "chasing laser pointers"
+             "lookin' hella cute"]})
+
+
+(comment
+  ;; Store Mittens in our DB
+  (pouch-put db mittens)
+
+  ;; increase the age of Mittens
+  (p/let [doc (pouch-get db "mittens")
+          _ (pouch-put db (update-in doc [:age] inc))
+          doc (pouch-get db "mittens")]
+    (prn doc))
+
+  ;; remove Mittens from DB
+  (p/->> (pouch-get db "mittens")
+         (pouch-rm db))
+  )

--- a/examples/pouchdb/package.json
+++ b/examples/pouchdb/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "clean": "rimraf kittens"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2"
+  },
+  "dependencies": {
+    "pouchdb": "^7.3.0"
+  }
+}


### PR DESCRIPTION
This demonstrates usage of PouchDB document database. 
Code loosely based on [Working with documents](https://pouchdb.com/guides/documents.html) examples.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).