### PR TITLE
nrepl: support pprinting eval results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## 0.3.98
+
+- `nrepl-server` supports pprinting eval results
+
 ## 0.3.97
 
 - `nrepl-server` supports `:host` parameter enabling connection within a Docker container.


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).
- [ ] ~This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).~ Discussed [in slack](https://clojurians.slack.com/archives/CBE668G4R/p1652122310856199?thread_ts=1652121305.385189&cid=CBE668G4R)
- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions
- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.

I took a shot at writing a test, but it's failing when I run it locally and I'm not sure why. The error I'm seeing is:
```
ERROR in (pprint-test) (/<path/to>/nbb/script/nbb_nrepl_tests.clj:)
Uncaught exception, not in assertion.
expected: nil
  actual: java.net.SocketException: Connection reset
 at java.net.SocketInputStream.read (SocketInputStream.java:186)
    java.net.SocketInputStream.read (SocketInputStream.java:140)
    java.net.SocketInputStream.read (SocketInputStream.java:200)
    java.io.FilterInputStream.read (FilterInputStream.java:83)
    java.io.PushbackInputStream.read (PushbackInputStream.java:136)
    bencode.core$read_byte.invokeStatic (core.clj:86)
    bencode.core$read_token.invokeStatic (core.clj:236)
    bencode.core$read_bencode.invokeStatic (core.clj:253)
    bencode.core$read_bencode.invoke (core.clj:253)
    sci.impl.vars.SciVar.invoke (vars.cljc:325)
    sci.impl.analyzer$return_call$reify__9575.eval (analyzer.cljc:1180)
    sci.impl.analyzer$return_call$reify__9575.eval (analyzer.cljc:1180)
    sci.impl.analyzer$analyze_call$reify__9668.eval (analyzer.cljc:1387)
    sci.impl.evaluator$eval_let$fn__7086.invoke (evaluator.cljc:65)
    sci.impl.evaluator$eval_let.invokeStatic (evaluator.cljc:56)
    sci.impl.analyzer$analyze_let_STAR_$reify__9247.eval (analyzer.cljc:503)
    sci.impl.analyzer$return_do$reify__8610.eval (analyzer.cljc:136)
    sci.impl.evaluator$eval_try.invokeStatic (evaluator.cljc:125)
    sci.impl.analyzer$analyze_try$reify__9330.eval (analyzer.cljc:758)
    sci.impl.evaluator$eval_let.invokeStatic (evaluator.cljc:74)
    sci.impl.analyzer$analyze_let_STAR_$reify__9247.eval (analyzer.cljc:503)
    sci.impl.evaluator$eval_try.invokeStatic (evaluator.cljc:125)
    sci.impl.analyzer$analyze_try$reify__9330.eval (analyzer.cljc:758)
    sci.impl.evaluator$eval_let.invokeStatic (evaluator.cljc:74)
    sci.impl.analyzer$analyze_let_STAR_$reify__9247.eval (analyzer.cljc:503)
    sci.impl.evaluator$eval_try.invokeStatic (evaluator.cljc:125)
    sci.impl.analyzer$analyze_try$reify__9330.eval (analyzer.cljc:758)
    sci.impl.evaluator$eval_let.invokeStatic (evaluator.cljc:74)
    sci.impl.analyzer$analyze_let_STAR_$reify__9247.eval (analyzer.cljc:503)
    sci.impl.evaluator$eval_try.invokeStatic (evaluator.cljc:125)
    sci.impl.analyzer$analyze_try$reify__9330.eval (analyzer.cljc:758)
    sci.impl.evaluator$eval_let.invokeStatic (evaluator.cljc:74)
    sci.impl.analyzer$analyze_let_STAR_$reify__9247.eval (analyzer.cljc:503)
    sci.impl.analyzer$return_do$reify__8612.eval (analyzer.cljc:136)
    sci.impl.fns$fun$arity_0__7894.invoke (fns.cljc:105)
    babashka.impl.clojure.test$test_var_impl$fn__34602.invoke (test.clj:719)
    babashka.impl.clojure.test$test_var_impl.invokeStatic (test.clj:719)
    babashka.impl.clojure.test$test_var_impl.invoke (test.clj:710)
    sci.impl.vars.SciVar.invoke (vars.cljc:325)
    babashka.impl.clojure.test$test_vars$fn__34639$fn__34644.invoke (test.clj:742)
    babashka.impl.clojure.test$default_fixture.invokeStatic (test.clj:689)
    babashka.impl.clojure.test$default_fixture.invoke (test.clj:685)
    babashka.impl.clojure.test$test_vars$fn__34639.invoke (test.clj:742)
    babashka.impl.clojure.test$default_fixture.invokeStatic (test.clj:689)
    babashka.impl.clojure.test$default_fixture.invoke (test.clj:685)
    babashka.impl.clojure.test$test_vars.invokeStatic (test.clj:738)
    babashka.impl.clojure.test$test_all_vars.invokeStatic (test.clj:745)
    babashka.impl.clojure.test$test_ns.invokeStatic (test.clj:767)
    babashka.impl.clojure.test$run_tests$fn__34659.invoke (test.clj:784)
    clojure.core$map$fn__5935.invoke (core.clj:2772)
    clojure.lang.LazySeq.sval (LazySeq.java:42)
    clojure.lang.LazySeq.seq (LazySeq.java:51)
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.boundedLength (RT.java:1790)
    clojure.lang.RestFn.applyTo (RestFn.java:130)
    clojure.core$apply.invokeStatic (core.clj:669)
    babashka.impl.clojure.test$run_tests.invokeStatic (test.clj:777)
    babashka.impl.clojure.test$run_tests.doInvoke (test.clj:777)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.core$apply.invokeStatic (core.clj:669)
    babashka.impl.test$contextualize$fn__34670.doInvoke (test.clj:7)
    clojure.lang.RestFn.invoke (RestFn.java:436)
    sci.impl.vars.SciVar.invoke (vars.cljc:329)
    sci.impl.analyzer$return_call$reify__9583.eval (analyzer.cljc:1180)
    sci.impl.analyzer$return_if$reify__9296.eval (analyzer.cljc:667)
    sci.impl.evaluator$eval_let$fn__7086.invoke (evaluator.cljc:65)
    sci.impl.evaluator$eval_let.invokeStatic (evaluator.cljc:56)
    sci.impl.analyzer$analyze_let_STAR_$reify__9247.eval (analyzer.cljc:503)
    sci.impl.fns$fun$arity_0__7390.doInvoke (fns.cljc:83)
    clojure.lang.RestFn.invoke (RestFn.java:397)
    clojure.lang.AFn.applyToHelper (AFn.java:152)
    clojure.lang.RestFn.applyTo (RestFn.java:132)
    clojure.core$apply.invokeStatic (core.clj:667)
    clojure.core$apply.invoke (core.clj:662)
    sci.impl.vars.SciVar.invoke (vars.cljc:327)
    sci.impl.analyzer$return_call$reify__9579.eval (analyzer.cljc:1180)
    sci.impl.analyzer$return_do$reify__8610.eval (analyzer.cljc:136)
    sci.impl.evaluator$eval_try.invokeStatic (evaluator.cljc:125)
    sci.impl.analyzer$analyze_try$reify__9330.eval (analyzer.cljc:758)
    sci.impl.analyzer$return_do$reify__8610.eval (analyzer.cljc:136)
    sci.impl.evaluator$eval_let.invokeStatic (evaluator.cljc:74)
    sci.impl.analyzer$analyze_let_STAR_$reify__9247.eval (analyzer.cljc:503)
    sci.impl.evaluator$eval_def.invokeStatic (evaluator.cljc:78)
    sci.impl.analyzer$analyze_def$reify__9264.eval (analyzer.cljc:568)
    sci.impl.interpreter$eval_form.invokeStatic (interpreter.cljc:39)
    sci.impl.interpreter$eval_string_STAR_.invokeStatic (interpreter.cljc:61)
    sci.core$eval_string_STAR_.invokeStatic (core.cljc:237)
    babashka.main$exec$fn__35890$fn__35891.invoke (main.clj:902)
    babashka.main$exec$fn__35890.invoke (main.clj:902)
    babashka.main$exec.invokeStatic (main.clj:892)
    babashka.main$main.invokeStatic (main.clj:992)
    babashka.main$main.doInvoke (main.clj:967)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:667)
    babashka.main$_main.invokeStatic (main.clj:1025)
    babashka.main$_main.doInvoke (main.clj:1017)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    babashka.main.main (:-1)
```

I tried just copying the print-test verbatim and changing the name of the deftest to see if the problem was in the setup somewhere and that failed too. I figured I'd stick the test in the PR anyways in case the problem is with my environment somehow.