### PR TITLE
Fix link to GCF

### DIFF
--- a/doc/aws_lambda.md
+++ b/doc/aws_lambda.md
@@ -74,4 +74,4 @@ Also check out these resources:
 - [nbb serverless example](https://github.com/vharmain/nbb-serverless-example)
 by Valtteri Harmainen
 - [Serverless site analytics with Clojure nbb and AWS](https://www.loop-code-recur.io/simple-site-analytics-with-serverless-clojure/) by Cyprien Pannier
-- [Nbb on Google Cloud Function](gloud_function.md).
+- [Nbb on Google Cloud Function](gcloud_functions.md)


### PR DESCRIPTION
Documentation fix

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).