### PR TITLE
Add pragmatic default for cljs.test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Next release
+
+- cljs.test defaults to failed tests result in failed process
+
 ## 0.4.100
 
 - nREPL improvements

--- a/doc/testing/example.cljs
+++ b/doc/testing/example.cljs
@@ -20,11 +20,6 @@
   (println "===" (-> m :var meta :name))
   (println))
 
-;; set exit code based on failing tests
-(defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
-  (when-not (cljs.test/successful? m)
-    (set! (.-exitCode js/process) 1)))
-
 ;; run this function with: nbb -m example/run-tests
 (defn run-tests []
   (t/run-tests 'example))

--- a/script/nbb_tests.clj
+++ b/script/nbb_tests.clj
@@ -207,6 +207,15 @@
                   deref
                   :exit)))))
 
+(deftest failing-test-results-in-failing-exit-code
+  (is (not
+       (zero?
+        (-> (nbb** "-e" "
+    (ns foo0 (:require [clojure.test :as t :refer [deftest is testing]]))
+    (t/deftest foo (t/is (= 1 2))) (t/run-tests 'foo0)")
+            deref
+            :exit)))))
+
 (defn parse-opts [opts]
   (let [[cmds opts] (split-with #(not (str/starts-with? % ":")) opts)]
     (into {:cmds cmds}

--- a/src/nbb/impl/clojure/test.cljs
+++ b/src/nbb/impl/clojure/test.cljs
@@ -394,7 +394,6 @@
 (defmethod report-impl [:cljs.test/default :begin-test-var] [m]
   #_(println ":begin-test-var" (testing-vars-str m)))
 (defmethod report-impl [:cljs.test/default :end-test-var] [m])
-(defmethod report-impl [:cljs.test/default :end-run-tests] [m])
 (defmethod report-impl [:cljs.test/default :end-test-all-vars] [m])
 (defmethod report-impl [:cljs.test/default :end-test-vars] [m])
 
@@ -531,7 +530,7 @@
 ;; macro.  These define different kinds of tests, based on the first
 ;; symbol in the test expression.
 
-(defmulti assert-expr 
+(defmulti assert-expr
   (fn [_menv _msg form]
     (cond
       (nil? form) :always-fail
@@ -1080,3 +1079,8 @@
   [summary]
   (and (zero? (:fail summary 0))
        (zero? (:error summary 0))))
+
+;; Exit 1 if there is a test failure or error
+(defmethod report-impl [:cljs.test/default :end-run-tests] [m]
+  (when-not (successful? m)
+    (set! (.-exitCode js/process) 1)))

--- a/test/nbb/test_test.cljs
+++ b/test/nbb/test_test.cljs
@@ -13,6 +13,7 @@
                           (swap! output str s))}
           (nbb/load-string "
     (ns foo0 (:require [clojure.test :as t :refer [deftest is testing]]))
+    (defmethod t/report [:cljs.test/default :end-run-tests] [m])
     (t/deftest foo (t/is (= 1 2))) (t/run-tests 'foo0)"))
         (.then (fn [_]
                  (is (str/includes? @output "expected: (= 1 2)  actual: (not (= 1 2))")))))))
@@ -24,6 +25,7 @@
                           (swap! output str s))}
           (nbb/load-string "
     (ns foo01 (:require [cljs.test :as t :refer [deftest is testing]]))
+    (defmethod t/report [:cljs.test/default :end-run-tests] [m])
     (t/deftest foo (t/is (= 1 2)))
     (cljs.test/deftest bar (t/is (= 1 2))) (t/run-tests 'foo01)"))
         (.then (fn [_]
@@ -36,6 +38,7 @@
                           (swap! output str s))}
           (nbb/load-string "
     (ns foo02 (:require [cljs.test :as t :refer-macros [deftest is]]))
+    (defmethod t/report [:cljs.test/default :end-run-tests] [m])
     (deftest foo (is (= 1 2))) (t/run-tests 'foo02)"))
         (.then (fn [_]
                  (is (str/includes? @output "expected: (= 1 2)  actual: (not (= 1 2))")))))))
@@ -48,6 +51,7 @@
       (->
        (nbb/load-string "
     (ns foo-are (:require [clojure.test :as t :refer [deftest is are testing]]))
+    (defmethod t/report [:cljs.test/default :end-run-tests] [m])
     (t/deftest foo (t/are [x] (= x 2) 1 2 3)) (t/run-tests 'foo-are)")
           (.then (fn [_]
                    (is (str/includes? @output "expected: (= 3 2)  actual: (not (= 3 2))"))))
@@ -85,6 +89,7 @@
            (sci/alter-var-root sci/print-newline (constantly true))
            (nbb/load-string "
     (ns foo1 (:require [clojure.test :as t :refer [deftest async is testing]]))
+    (defmethod t/report [:cljs.test/default :end-run-tests] [m])
     (deftest foo (async done
                    (js/setTimeout #(do (t/is (= 1 2)) (done)) 300)))
     (t/run-tests 'foo1)")
@@ -173,6 +178,8 @@
                (nbb/load-string "
 (ns foo4
   (:require [clojure.test :as t :refer [report]]))
+
+(defmethod t/report [:cljs.test/default :end-run-tests] [m])
 
 (def state (atom []))
 


### PR DESCRIPTION
Was finding myself copying this behavior in multiple places. This seems like a more pragmatic and friendlier default for using cljs.test

---
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
