### PR TITLE
Add exclusion for downstream nbb builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
-## Next release
+## 0.5.x
 
-- cljs.test defaults to failed tests result in failed process
+- Add deps.edn exclusion so that downstream builds can build
 
 ## 0.5.102
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## 0.5.x
 
-- Add deps.edn exclusion so that downstream builds can build
+- Bump shadow-cljs and fix custom nbb builds
 
 ## 0.5.102
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["src"]
  :aliases {:test {:extra-paths ["test"]}}
  :deps {thheller/shadow-cljs {:mvn/version "2.18.0"}
-        org.clojure/clojurescript {:mvn/version "1.11.51"}
+        org.clojure/clojurescript {:mvn/version "1.11.51"
+                                   :exclusions [com.google.javascript/closure-compiler-unshaded]}
         com.google.javascript/closure-compiler-unshaded {:mvn/version "v20220301"}
         ;; reagent/reagent {:mvn/version "1.0.0"}
         cljsjs/react {:mvn/version "17.0.2-0"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,7 @@
 {:paths ["src"]
  :aliases {:test {:extra-paths ["test"]}}
- :deps {thheller/shadow-cljs {:mvn/version "2.18.0"}
-        org.clojure/clojurescript {:mvn/version "1.11.51"
-                                   :exclusions [com.google.javascript/closure-compiler-unshaded]}
-        com.google.javascript/closure-compiler-unshaded {:mvn/version "v20220301"}
+ :deps {thheller/shadow-cljs {:mvn/version "2.19.0"}
+        org.clojure/clojurescript {:mvn/version "1.11.51"}
         ;; reagent/reagent {:mvn/version "1.0.0"}
         cljsjs/react {:mvn/version "17.0.2-0"}
         cljsjs/react-dom {:mvn/version "17.0.2-0"}


### PR DESCRIPTION
Hi @borkdude. I updated nbb-features to the latest nbb release and saw [this failure](https://github.com/babashka/nbb-features/runs/6454499514?check_suite_focus=true) for `bb release`. Looks like the `com.google.javascript/closure-compiler-unshaded` top-level override doesn't work when nbb's deps.edn is pulled in as a dependency. Adding this exclusion [fixed the issue I was seeing](https://github.com/babashka/nbb-features/actions/runs/2333467348).

---
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
