### PR TITLE
Fix #219: dynamic import resolves incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## 0.6.125
+
+- Fix [#219](https://github.com/babashka/nbb/issues/219): nbb doesn't resolve local node_modules when using the dynamic `js/import`
+
 ## 0.6.124
 
 - Fix [#136](https://github.com/babashka/nbb/issues/136): allow `set!` on any var

--- a/src/nbb/core.cljs
+++ b/src/nbb/core.cljs
@@ -53,7 +53,11 @@
 
 (def sci-ctx (atom nil))
 
-(set! (.-import goog/global) esm/dynamic-import)
+(set! (.-import goog/global) (fn [what]
+                               ;; need to resolve based on the current file
+                               (await
+                                (-> ((:resolve @ctx) what)
+                                    (.then #(esm/dynamic-import %))))))
 
 (def loaded-modules (atom {}))
 

--- a/test-scripts/esm-test/script.cljs
+++ b/test-scripts/esm-test/script.cljs
@@ -26,3 +26,6 @@
 (await (zx/$ #js ["ls"]))
 
 (prn (execa/execaSync "ls"))
+
+(def term-size' (await (js/import "term-size")))
+(prn (term-size'.default))

--- a/test-scripts/esm-test/script.cljs
+++ b/test-scripts/esm-test/script.cljs
@@ -29,3 +29,6 @@
 
 (def term-size' (await (js/import "term-size")))
 (prn (term-size'.default))
+
+(def js-file (await (js/import "./test-js-file.js")))
+(assert (= 10 (:x js-file)))

--- a/test-scripts/esm-test/test-js-file.js
+++ b/test-scripts/esm-test/test-js-file.js
@@ -1,0 +1,1 @@
+export const x = 10;


### PR DESCRIPTION
Calling `esm/dynamic-import` directly interprets the nbb main file as the current file and looks to resolve the import from there.  This changes `js/import` to resolve the string from the file where it was called.

Let me know if I should change the test or changelog; those were what I was most unsure of.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/issues/219).

- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
