### PR TITLE
Allow Npm lib in bundle to be configured with env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## 0.6.X
+
+- Allow npm lib name in bundle to be configured with `$NBB_NPM_LIB_NAME`
+
 ## 0.6.129
 
 - Malli compatibility

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -59,8 +59,11 @@ The two main build tasks are `bb dev` and `bb release` for development and
 production builds respectively. Some build tasks are available as a bb library
 in `build/`. This is useful for custom builds with features enabled.
 
-To build a version of nbb with a custom cli name use `$NBB_CLI_NAME` e.g.
-`NBB_CLI_NAME=nbb-datascript bb release`.
+To build a version of nbb with a custom cli name, use `$NBB_CLI_NAME` e.g.
+`NBB_CLI_NAME=nbb-logseq bb release`.
+
+To build a version of nbb with a custom npm lib for bundle, use `$NBB_NPM_LIB_NAME` e.g.
+`NBB_NPM_LIB_NAME=@logseq/nbb-logseq bb release`.
 
 ## Features
 

--- a/src/nbb/core.cljs
+++ b/src/nbb/core.cljs
@@ -121,6 +121,9 @@
 (def feature-requires
   (macros/feature-requires))
 
+(defn npm-lib-name []
+  (macros/npm-lib-name))
+
 (defn split-libname [libname]
   (str/split libname #"\$" 2))
 

--- a/src/nbb/impl/bundler.cljs
+++ b/src/nbb/impl/bundler.cljs
@@ -191,17 +191,17 @@ Options:
             (swap! expressions conj file)
             (uberscript {:ctx ctx
                          :expressions [file]}))
-        (print! "import { loadFile, loadString, registerModule } from 'nbb'")
+        (print! (gstring/format "import { loadFile, loadString, registerModule } from '%s'"
+                                (nbb/npm-lib-name)))
         (doseq [lib (distinct @js-libs)]
           (let [internal (munge lib) #_(nbb/libname->internal-name lib)
                 js-internal (str/replace (str internal) "." "_dot_")]
             (print! (gstring/format "import * as %s from '%s'" js-internal lib))
             (print! (gstring/format "registerModule(%s, '%s')" js-internal lib))))
         (doseq [lib (distinct @built-ins)]
-          (print! (gstring/format "import 'nbb/lib/%s'" lib)))
+          (print! (gstring/format "import '%s/lib/%s'" (nbb/npm-lib-name) lib)))
         (doseq [expr (distinct @expressions)]
           (print! (gstring/format "await loadString(%s)" (pr-str expr))))
         (if-let [out-file (:out parsed-opts)]
           (fs/writeFileSync out-file @out "utf-8")
           (println @out))))))
-

--- a/src/nbb/macros.clj
+++ b/src/nbb/macros.clj
@@ -17,6 +17,10 @@
   []
   (or (System/getenv "NBB_CLI_NAME") "nbb"))
 
+(defmacro npm-lib-name
+  []
+  (or (System/getenv "NBB_NPM_LIB_NAME") "nbb"))
+
 (defmacro feature-requires []
   (let [;; all nbb_features.edn files on the classpath:
         configs (enumeration-seq


### PR DESCRIPTION
Hi @borkdude. Here's the small enhancement I mentioned in slack. This allows nbb-logseq to use the bundle command to successfully generate `out.mjs`. Example use is in the docs

---
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
