### PR TITLE
Support downloading and installing dependencies via nbb.edn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ ext/**/index.mjs
 output.html
 doc/bundle/dist
 doc/bundle/out.mjs
+/.nbb/

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ ext/**/index.mjs
 output.html
 doc/bundle/dist
 doc/bundle/out.mjs
-/.nbb/
+.nbb/.cache/

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -60,6 +60,8 @@
                :depends-on #{:nbb_core}}
     :nbb_bundler {:init-fn nbb.impl.bundler/init
                   :depends-on #{:nbb_core :nbb_goog_string}}
+    :nbb_deps {:init-fn nbb.impl.deps/init
+               :depends-on #{:nbb_core}}
     #_#_:nbb_schema {:init-fn nbb.impl.schema/init
                  :depends-on #{:nbb_core :nbb_goog_string}}
     #_#_:nbb_malli {:init-fn nbb.impl.malli/init

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -3,7 +3,7 @@
    ["child_process" :as cproc]
    ["crypto" :as crypto]
    ["fs" :as fs]
-   ["os" :as os]))
+   [nbb.core :as nbb :refer [opts]]))
 
 
 (def default-nbb-cache-path
@@ -39,3 +39,9 @@
                            "\")'"))
       (println "Done."))
     unzipped-path))
+
+
+(defn init
+  []
+  (when-let [deps (get-in @opts [:config :deps])]
+    (download-and-extract-deps! deps default-nbb-cache-path)))

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -6,7 +6,7 @@
    ["os" :as os]))
 
 
-(def default-nbb-path
+(def default-nbb-cache-path
   ".nbb/.cache")
 
 

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -32,4 +32,3 @@
                            unzipped-path
                            "\")'")))
     unzipped-path))
-

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -26,7 +26,6 @@
         jar-path (str deps-path "/nbb-deps.jar")
         unzipped-path (str deps-path "/nbb-deps")]
     (when-not (fs/existsSync unzipped-path)
-      (println "Dependency changes detected.")
       (fs/mkdirSync deps-path #js {:recursive true})
       (println "Downloading dependencies...")
       (cproc/execSync (str "bb --config nbb.edn uberjar " jar-path))

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -1,0 +1,36 @@
+(ns nbb.impl.deps
+  (:require
+   ["child_process" :as cproc]
+   ["crypto" :as crypto]
+   ["fs" :as fs]
+   ["os" :as os]
+   ))
+
+
+(def default-nbb-path
+  (str (os/homedir) "/.nbb"))
+
+
+(defn hash-deps
+  "Given a map of dependencies, generates a unique hash of that map for
+  caching purposes."
+  [deps]
+  (.. (crypto/createHash "sha1") (update (str deps) "binary") (digest "hex")))
+
+
+(defn download-and-extract-deps!
+  [deps nbb-path]
+  (let [deps-hash (hash-deps deps)
+        deps-path (str nbb-path "/_deps/" deps-hash)
+        jar-path (str deps-path "/nbb-deps.jar")
+        unzipped-path (str deps-path "/nbb-deps")]
+    (when-not (fs/existsSync unzipped-path)
+      (fs/mkdirSync deps-path #js {:recursive true})
+      (cproc/execSync (str "bb --config nbb.edn uberjar " jar-path))
+      (cproc/execSync (str "bb -e '(fs/unzip \""
+                           jar-path
+                           "\" \""
+                           unzipped-path
+                           "\")'")))
+    unzipped-path))
+

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -18,6 +18,8 @@
 
 
 (defn download-and-extract-deps!
+  "Given a map of dependencies and a path, downloads all dependencies to
+  '*nbb-path*/_deps/*hash-of-deps-map*/nbb-deps' and returns that full path."
   [deps nbb-path]
   (let [deps-hash (hash-deps deps)
         deps-path (str nbb-path "/_deps/" deps-hash)

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -3,8 +3,7 @@
    ["child_process" :as cproc]
    ["crypto" :as crypto]
    ["fs" :as fs]
-   ["os" :as os]
-   ))
+   ["os" :as os]))
 
 
 (def default-nbb-path

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -22,7 +22,7 @@
   '*nbb-path*/_deps/*hash-of-deps-map*/nbb-deps' and returns that full path."
   [deps nbb-path]
   (let [deps-hash (hash-deps deps)
-        deps-path (str nbb-path deps-hash)
+        deps-path (str nbb-path "/" deps-hash)
         deps-edn-path (str deps-path "/deps.edn")
         jar-path (str deps-path "/nbb-deps.jar")
         unzipped-path (str deps-path "/nbb-deps")]

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -7,7 +7,7 @@
 
 
 (def default-nbb-path
-  (str (os/homedir) "/.nbb"))
+  ".nbb/.cache")
 
 
 (defn hash-deps
@@ -22,7 +22,7 @@
   '*nbb-path*/_deps/*hash-of-deps-map*/nbb-deps' and returns that full path."
   [deps nbb-path]
   (let [deps-hash (hash-deps deps)
-        deps-path (str nbb-path "/_deps/" deps-hash)
+        deps-path (str nbb-path deps-hash)
         deps-edn-path (str deps-path "/deps.edn")
         jar-path (str deps-path "/nbb-deps.jar")
         unzipped-path (str deps-path "/nbb-deps")]

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -23,12 +23,14 @@
   [deps nbb-path]
   (let [deps-hash (hash-deps deps)
         deps-path (str nbb-path "/_deps/" deps-hash)
+        deps-edn-path (str deps-path "/deps.edn")
         jar-path (str deps-path "/nbb-deps.jar")
         unzipped-path (str deps-path "/nbb-deps")]
     (when-not (fs/existsSync unzipped-path)
       (fs/mkdirSync deps-path #js {:recursive true})
+      (fs/writeFileSync deps-edn-path (str {:deps deps}))
       (println "Downloading dependencies...")
-      (cproc/execSync (str "bb --config nbb.edn uberjar " jar-path))
+      (cproc/execSync (str "bb --config " deps-edn-path " uberjar " jar-path))
       (println "Extracting dependencies...")
       (cproc/execSync (str "bb -e '(fs/unzip \""
                            jar-path

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -3,6 +3,7 @@
    ["child_process" :as cproc]
    ["crypto" :as crypto]
    ["fs" :as fs]
+   [nbb.classpath :as cp]
    [nbb.core :as nbb :refer [opts]]))
 
 
@@ -44,4 +45,6 @@
 (defn init
   []
   (when-let [deps (get-in @opts [:config :deps])]
-    (download-and-extract-deps! deps default-nbb-cache-path)))
+    (-> deps
+        (download-and-extract-deps! default-nbb-cache-path)
+        (cp/add-classpath))))

--- a/src/nbb/impl/deps.cljs
+++ b/src/nbb/impl/deps.cljs
@@ -26,11 +26,15 @@
         jar-path (str deps-path "/nbb-deps.jar")
         unzipped-path (str deps-path "/nbb-deps")]
     (when-not (fs/existsSync unzipped-path)
+      (println "Dependency changes detected.")
       (fs/mkdirSync deps-path #js {:recursive true})
+      (println "Downloading dependencies...")
       (cproc/execSync (str "bb --config nbb.edn uberjar " jar-path))
+      (println "Extracting dependencies...")
       (cproc/execSync (str "bb -e '(fs/unzip \""
                            jar-path
                            "\" \""
                            unzipped-path
-                           "\")'")))
+                           "\")'"))
+      (println "Done."))
     unzipped-path))

--- a/src/nbb/impl/main.cljs
+++ b/src/nbb/impl/main.cljs
@@ -109,8 +109,8 @@ Tooling:
 (defn local-nbb-edn
   "Finds a local nbb.edn file and reads it. Returns nil if none found."
   []
-  (when-let [file (some #(when (= "nbb.edn" %) %) (fs/readdirSync "."))]
-    (edn/read-string (fs/readFileSync file "utf8"))))
+  (when (fs/existsSync "nbb.edn")
+    (edn/read-string (fs/readFileSync "nbb.edn" "utf8"))))
 
 
 (defn main []

--- a/src/nbb/impl/main.cljs
+++ b/src/nbb/impl/main.cljs
@@ -47,6 +47,9 @@
           ("-cp" "--classpath")
           (recur (assoc opts :classpath (first nargs))
                  (next nargs))
+          "--config" (recur (assoc opts :config
+                                   (edn/read-string (first nargs)))
+                            (next nargs))
           "--debug" (recur (assoc opts :debug true)
                            nargs)
           "nrepl-server" (recur (assoc opts :nrepl-server true)
@@ -116,7 +119,7 @@ Tooling:
         opts (parse-args args)
         _ (reset! common/opts opts)
         script-file (:script opts)
-        nbb-edn (local-nbb-edn)
+        nbb-edn (or (:config opts) (local-nbb-edn))
         expr (:expr opts)
         classpath (:classpath opts)
         cwd (js/process.cwd)

--- a/src/nbb/impl/main.cljs
+++ b/src/nbb/impl/main.cljs
@@ -133,7 +133,7 @@ Tooling:
                   (empty? (dissoc opts :classpath :debug)))
         bundle-opts (:bundle-opts opts)]
     (when-let [deps (:deps nbb-edn)]
-      (-> (deps/download-and-extract-deps! deps deps/default-nbb-path)
+      (-> (deps/download-and-extract-deps! deps deps/default-nbb-cache-path)
           (cp/add-classpath)))
     (when (:help opts)
       (print-help)

--- a/src/nbb/impl/main.cljs
+++ b/src/nbb/impl/main.cljs
@@ -46,8 +46,7 @@
           ("-cp" "--classpath")
           (recur (assoc opts :classpath (first nargs))
                  (next nargs))
-          "--config" (recur (assoc opts :config
-                                   (edn/read-string (first nargs)))
+          "--config" (recur (assoc opts :config (first nargs))
                             (next nargs))
           "--debug" (recur (assoc opts :debug true)
                            nargs)
@@ -117,7 +116,11 @@ Tooling:
   (let [[_ _ & args] js/process.argv
         opts (parse-args args)
         opts (if (:config opts)
-               opts
+               (assoc opts :config
+                      (edn/read-string
+                       (fs/readFileSync
+                        (:config opts)
+                        "utf8")))
                (if-let [config (local-nbb-edn)]
                  (assoc opts :config config)
                  opts))
@@ -133,7 +136,7 @@ Tooling:
         repl? (or (:repl opts)
                   (:socket-repl opts)
                   ;; TODO: better handling of detecting invocation without subtask
-                  (empty? (dissoc opts :classpath :debug)))
+                  (empty? (dissoc opts :classpath :debug :config)))
         bundle-opts (:bundle-opts opts)]
     (when (:help opts)
       (print-help)

--- a/test/nbb/main_test.cljs
+++ b/test/nbb/main_test.cljs
@@ -40,8 +40,8 @@
          (main/parse-args ["-m" "foo" "1" "2" "3"])))
   (is (= {:nrepl-server true, :port "0.0.0.0"}
       (main/parse-args ["nrepl-server" "--port" "0.0.0.0" ])))
-  (is (= {:config '{:deps {foo/bar {:mvn/version "1.0.0"}}}}
-         (main/parse-args ["--config" "{:deps {foo/bar {:mvn/version \"1.0.0\"}}}"]))))
+  (is (= {:config "../foo/nbb.edn"}
+         (main/parse-args ["--config" "../foo/nbb.edn"]))))
 
 (deftest-async simple-require-test
   (-> (nbb/load-string "(ns foo (:require cljs.core clojure.set))

--- a/test/nbb/main_test.cljs
+++ b/test/nbb/main_test.cljs
@@ -39,7 +39,9 @@
   (is (= {:expr "(require 'foo) (apply foo/-main *command-line-args*)", :args '("1" "2" "3")}
          (main/parse-args ["-m" "foo" "1" "2" "3"])))
   (is (= {:nrepl-server true, :port "0.0.0.0"}
-      (main/parse-args ["nrepl-server" "--port" "0.0.0.0" ]))))
+      (main/parse-args ["nrepl-server" "--port" "0.0.0.0" ])))
+  (is (= {:config '{:deps {foo/bar {:mvn/version "1.0.0"}}}}
+         (main/parse-args ["--config" "{:deps {foo/bar {:mvn/version \"1.0.0\"}}}"]))))
 
 (deftest-async simple-require-test
   (-> (nbb/load-string "(ns foo (:require cljs.core clojure.set))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).
- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.

---

This is a prototype of solving https://github.com/babashka/nbb/issues/20 by essentially encapsulating the guidance given in https://github.com/babashka/nbb/blob/51bf9dda0ee5392ce4b8f44054d6b8f4c5259ad4/doc/dependencies.md.

It adds the following capabilities to `nbb`:
- A new `--config` CLI arg which expects a deps.edn-like map as the following arg
- If `--config` is not passed, looks in the immediate local directory for an `nbb.edn` file, and if present reads it in as EDN

If a config map is available via the above methods, then does the following:
- Looks up `:deps` in the map loaded via the above methods, and hashes the value using `sha1` for caching purposes
- If `~/.nbb/_deps/*deps-hash*` doesn't exist yet, creates it and uses `bb` to download dependencies and create an uberjar. Extracts the uberjar to `~/.nbb/_deps/*deps-hash*/nbb-deps`
- Adds `~/.nbb/_deps/*deps-hash*/nbb-deps` to class path

Since you responded to https://github.com/babashka/nbb/issues/20#issuecomment-1193393740 saying that shelling out to `bb` is fine, the only thing I'm not sure about is the `~/.nbb/_deps` folder being where the jar is download to. I'm thinking I might change this to a local directory like `.nbb` or `.nbb-cache`. Thoughts?