### PR TITLE
add redis example

### DIFF
--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -1,0 +1,12 @@
+# redis example
+
+this example is how to use the [redis package (from node)](https://github.com/redis/node-redis) that works with many background operations (async).
+
+## run
+
+Now you're ready to run the example in `example.cljs` file.
+
+```sh
+npm install # install redis dependence (node package)
+nbb example.cljs
+```

--- a/examples/redis/example.cljs
+++ b/examples/redis/example.cljs
@@ -1,0 +1,20 @@
+(ns example
+  (:require ["redis$default" :as redis]
+            [nbb.core :as nbb]
+            [promesa.core :as p]))
+
+(def client
+  "initialize the redis client"
+  (nbb/await
+   (redis/createClient
+    #js{:url "redis://127.0.0.1:6379"})))
+
+(nbb/await
+ (p/let [db client]
+   (.connect db)
+   (p/do
+     ;; operations on redis (in this case, set and get)
+     (.set db "my-key" (js/JSON.stringify (clj->js {:a 1 :b 2})))
+     (p/then (.get db "my-key") prn))
+   ;; close the connection after performing operations
+   (.disconnect db)))

--- a/examples/redis/package.json
+++ b/examples/redis/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "redis": "^4.5.0"
+  }
+}


### PR DESCRIPTION
The packages that work with databases on the node have a habitof using a lot of background calls (async), so we have to use promises to perform operations and get returns.

After implementing [bots.clj.social](https://github.com/avelino/bots.clj.social) (which uses redis, I thought it was important to have an example of redis here.

---

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
