### PR TITLE
Fix nrepl server last-ns name deref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ##  Unreleased
 
+- [#303](https://github.com/babashka/nbb/issues/303) nREPL server sends bad namespace value in eval responses.
+
 ## 1.2.161
 
 - [#302](https://github.com/babashka/nbb/issues/302): top level `do` expressions did not allow non-seq? values

--- a/README.md
+++ b/README.md
@@ -524,7 +524,17 @@ In Calva connect to the REPL with:
 
 #### CIDER
 
-Currently CIDER needs the following
+Use `cider-jack-in-cljs` as usual to start the nbb nREPL server from within an nbb project
+
+or start an nREPL server from the command line with
+
+``` shell
+$ nbb nrepl-server
+```
+
+and use `cider-connect-cljs` with a ClojureScript REPL type of `nbb` to connect to it.
+
+CIDER prior to v1.6.0, needs the following
 [workaround](https://github.com/clojure-emacs/cider/issues/3061).
 
 See also [this article](https://benjamin-asdf.github.io/faster-than-light-memes/jacking-nbb.html) by Benjamin Scherdtner.

--- a/bb.edn
+++ b/bb.edn
@@ -90,7 +90,8 @@
                    (run 'clean)
                    (run 'release)
                    (run 'run-tests)
-                   (run 'run-integration-tests))}
+                   (run 'run-integration-tests)
+                   (run 'nrepl-tests))}
 
   ci:test-build {:doc "Runs tests for build library"
                  :requires ([nbb-build-tests]

--- a/script/nbb_nrepl_tests.clj
+++ b/script/nbb_nrepl_tests.clj
@@ -74,6 +74,8 @@
               v (:value msg)
               _ (is (= "nil" v))
               msg (read-reply in session @id)
+              ns (:ns msg)
+              _ (is (= "user" ns))
               status (:status msg)
               _ (is (= ["done"] status))]))
       (testing "print with delay"

--- a/src/nbb/impl/nrepl_server.cljs
+++ b/src/nbb/impl/nrepl_server.cljs
@@ -138,7 +138,7 @@
                       (send-fn request {"ex" (str e)
                                         "ns" (str @sci/ns)}))))
           (.finally (fn []
-                      (send-fn request {"ns" (str last-ns)
+                      (send-fn request {"ns" (str @last-ns)
                                         "status" ["done"]})))))))
 
 (defn handle-eval [{:keys [ns] :as request} send-fn]


### PR DESCRIPTION
Hi,

could you please consider fix for bad namespace value sent in nREPL eval responses. Fixes #303.

I've updated one of the tests to test the same, and also included the nREPL tests in the ci runs (I assumed they were forgotten).

I've also update CIDER instructions in README.md to reflect CIDER's explicit nbb support since v1.6.0.

Thanks

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x ] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
