### PR TITLE
Always emit final newline in println to nREPL clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 [Nbb](https://github.com/babashka/nbb): Scripting in Clojure on Node.js using [SCI](https://github.com/babashka/sci)
 
+## Unreleased
+
+- [#330](https://github.com/babashka/nbb/issues/330): Update nREPL server to always have `println` to emit the final newline to nREPL clients even from inside async calls such as `js/setTimeout`.
+
 ## 1.2.174
 
 - [#323](https://github.com/babashka/nbb/issues/323): regression: `cljs.core/PersistentQueue.EMPTY` no longer works

--- a/script/nbb_nrepl_tests.clj
+++ b/script/nbb_nrepl_tests.clj
@@ -89,6 +89,17 @@
               msg (read-reply in session @id)
               out (:out msg)
               _ (is (= "{:delayed-by \"1 second\"}" out))]))
+      (testing "async println"
+        (bencode/write-bencode os {"op" "eval" "code"
+                                   "(js/setTimeout #(do (println 123)) 10)"
+                                   "session" session "id" (new-id!)})
+        (let [_tm (read-reply in session @id)
+              done (read-reply in session @id)
+              _ (is (= ["done"] (:status done)))
+              msg (read-reply in session @id)
+              _ (is (= "123" (:out msg)))
+              nl (read-reply in session @id)
+              _ (is (= "\n" (:out nl)))]))
       (bencode/write-bencode os {"op" "eval" "code" "(js/process.exit 0)"
                                  "session" session "id" (new-id!)}))))
 


### PR DESCRIPTION
Hi,

can you please consider work around for sending the final newline in `println` to nREPL clients from an async call such as `js/setTimeout`. It fixes #330.

The issue is that normally `println` does not emit the final newline but delegates this to `js/console`. Though when sending to nREPL client we'd like it to emit it. This behaviour is controlled by the `*print-newline*` var in cljs which is referenced by `sci/new-printline` in `sci`.

Although the nrepl-server sets the aforemention dynamic var to true when evaluating client code, the binding is lost by the time any async calls are made, and then the newline is not send over to the client.

The workaround here is to reset the root of the dynamic var in sci so that it is always set to true (i.e. print final newline), and restore when the server is exited. The ideal solution would be for sci to support dynamic binding in async calls as discussed in#330.

I've also noticed that the `sci/print-fn` dyn var was also set by the server but never restored, so I also restored it on exit.

Thanks

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x]  This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
