### PR TITLE
Refactor ink-demo to use setInterval for consistent memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,12 @@ $ npm install ink
 
 (defonce state (r/atom 0))
 
-(doseq [n (range 1 11)]
-  (js/setTimeout #(swap! state inc) (* n 500)))
+(def count
+  (js/setInterval
+   #(if (< @state 10)
+      (swap! state inc)
+      (js/clearInterval count))
+   500))
 
 (defn hello []
   [:> Text {:color "green"} "Hello, world! " @state])


### PR DESCRIPTION

 This code has a large memory overhead when n is large

```clojure
(doseq [n (range 1 11)]
    (js/setTimeout #(swap! state inc) (* n 500)))
```
Therefore, use `setInterval` instead.
```clojure
(def count
  (js/setInterval
   #(if (< @state 10)
      (swap! state inc)
      (js/clearInterval count))
   500))
```