### PR TITLE
Add atom var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 [Nbb](https://github.com/babashka/nbb): Scripting in Clojure on Node.js using [SCI](https://github.com/babashka/sci)
 
+## Unreleased
+
+- Add cljs.core/Atom
+
 ## 1.2.179 (2023-10-05)
 
 - Expose `sci.core` in nbb

--- a/src/nbb/core.cljs
+++ b/src/nbb/core.cljs
@@ -596,6 +596,7 @@
                                'add-tap (sci/copy-var add-tap core-ns)
                                'remove-tap (sci/copy-var remove-tap core-ns)
                                'uuid (sci/copy-var uuid core-ns)
+                               'Atom (sci/copy-var Atom core-ns)
                                'IEditableCollection (sci/copy-var IEditableCollection core-ns)
                                'MapEntry (sci/copy-var MapEntry core-ns)
                                'UUID (sci/copy-var UUID core-ns)

--- a/test/nbb/main_test.cljs
+++ b/test/nbb/main_test.cljs
@@ -301,6 +301,11 @@ result")
              (fn [val]
                (is (= 1 val))))))
 
+(deftest-async atom-instance-test
+  (is (.then (nbb/load-string "(instance? cljs.core/Atom (atom {}))")
+             (fn [val]
+               (is (true? val))))))
+
 (deftest-async macro-with-referred-js-function-test
   (is (.then (nbb/load-string "(ns foo (:require [\"fs\" :refer [readFileSync]]))
 (defmacro read [f] `(readFileSync ~f \"UTF-8\"))


### PR DESCRIPTION
Hi @borkdude. The motivation for adding this to nbb is I'd like to be able to check if something is an Atom e.g. `(instance? cljs.core/Atom state)`. While loading [this file](https://github.com/logseq/logseq/pull/10793/files#diff-7a301b7397e7f918dca1b572825d342e19d94f23911410dffaa233d81f752c2d) into nbb, this was the only cljs code that couldn't load normally. I didn't add a test since I didn't see any for just var additions but happy to do so if you'd like

---

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
