### PR TITLE
Fix testing macro candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 [Nbb](https://github.com/babashka/nbb): Scripting in Clojure on Node.js using [SCI](https://github.com/babashka/sci)
 
+## 1.3.0 (2024-06-25)
+
+- Removed cljs.test/_testing-contexts_
+- Fixed testing macro to update env testing-contexts
+
 ## 1.2.188 (2024-04-17)
 
 - nbb bundle JS output will ignore `nbb.edn`
@@ -87,7 +92,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - [#306](https://github.com/babashka/nbb/issues/306): nREPL server exits on evaluation error
 
-##  1.2.162
+## 1.2.162
 
 - [#303](https://github.com/babashka/nbb/issues/303) nREPL server sends bad namespace value in eval responses.
 
@@ -134,7 +139,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - Add support for executing function using [babashka.cli](https://github.com/babashka/cli):
 
-    nbb -x foo.bar/baz --flag --option 1
+  nbb -x foo.bar/baz --flag --option 1
 
 ## 1.1.150 (2022-11-27)
 
@@ -326,6 +331,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Fix [#180](https://github.com/babashka/nbb/issues/180): namespace resolution in REPL
 
 ## 0.3.10
+
 - Migrate features support to classpath approach
 - Provide build bb library for building features
 - Include `reagent.core/reactify-component`

--- a/deps.edn
+++ b/deps.edn
@@ -24,5 +24,5 @@
         org.babashka/cli {:mvn/version "0.7.53"}
         #_{:local/root "/Users/borkdude/dev/babashka/sci"}
         io.github.babashka/sci.configs #_{:local/root "../sci.configs"}
-                                       {:git/url "https://github.com/jaidetree/sci.configs"
-                                        :git/sha "59fb40b2e21c5e5053829884f0e0819cf2348e6e"}}}
+                                       {:git/url "https://github.com/babashka/sci.configs"
+                                        :git/sha "ccd66249ca6be59b2892ee7cf075c81aa6e6ff3d"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -24,5 +24,5 @@
         org.babashka/cli {:mvn/version "0.7.53"}
         #_{:local/root "/Users/borkdude/dev/babashka/sci"}
         io.github.babashka/sci.configs #_{:local/root "../sci.configs"}
-                                       {:git/url "https://github.com/babashka/sci.configs"
-                                        :git/sha "ffa88d796a3a2fe0a0fce332c6bf56f36b7c5cd7"}}}
+                                       {:git/url "https://github.com/jaidetree/sci.configs"
+                                        :git/sha "59fb40b2e21c5e5053829884f0e0819cf2348e6e"}}}

--- a/test/nbb/test_test.cljs
+++ b/test/nbb/test_test.cljs
@@ -53,11 +53,11 @@
     (ns foo-are (:require [clojure.test :as t :refer [deftest is are testing]]))
     (defmethod t/report [:cljs.test/default :end-run-tests] [m])
     (t/deftest foo (t/are [x] (= x 2) 1 2 3)) (t/run-tests 'foo-are)")
-          (.then (fn [_]
-                   (is (str/includes? @output "expected: (= 3 2)  actual: (not (= 3 2))"))))
-          (.then (fn [_]
-                   (reset! output "")
-                   (nbb/load-string "
+       (.then (fn [_]
+                (is (str/includes? @output "expected: (= 3 2)  actual: (not (= 3 2))"))))
+       (.then (fn [_]
+                (reset! output "")
+                (nbb/load-string "
     (ns foo-are2 (:require [clojure.test :as t :refer [deftest is are testing]]))
     (deftest are-test
     (are [x y] (= x y)
@@ -71,8 +71,8 @@
        2 (inc 1)
        2 (inc 1)))
     (t/run-tests 'foo-are2)")))
-          (.then (fn [_]
-                   (is (str/includes? @output " 9 assertions"))))))))
+       (.then (fn [_]
+                (is (str/includes? @output " 9 assertions"))))))))
 
 (deftest async-test-test
   (async done
@@ -96,7 +96,7 @@
            (let [f (fn f [t]
                      (js/setTimeout (fn []
                                       (cond (and (str/includes? @output "expected: (= 1 2)")
-                                               (str/includes? @output "actual: (not (= 1 2))"))
+                                                 (str/includes? @output "actual: (not (= 1 2))"))
                                             (do (is (= :expected-output :expected-output))
                                                 (restore)
                                                 (done))
@@ -217,3 +217,8 @@
               (fn [m]
                 (is (= :hello m))
                 (done))))))
+
+(deftest testing-test
+  (t/testing "Testing macro test"
+    (is (= (first (get-in (t/get-current-env) [:testing-contexts]))
+           "Testing macro test"))))


### PR DESCRIPTION
This is a candidate PR for fixing #358. This should not be merged as-is given it's pointing to my fork of sci.configs instead of upstream.

In changelog, proposed 1.2.188 -> 1.3.0 given this removes `cljs.test/*testing-contexts*` in favor of storing it in the `*current-env*`. That said, not likely to cause breaking changes for existing projects. No objections to whatever you want to do there.

---

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
