### PR TITLE
clarify reader-conditional docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,8 +425,8 @@ See the [example](examples/js-interop/example.cljs) of what is currently support
 
 ## Reader conditionals
 
-Nbb supports the following reader conditional features: `:org.babashka/nbb` and
-`:cljs` in that order of priority:
+Nbb supports the following reader conditional platform tags: `:org.babashka/nbb` and
+`:cljs`.  Whichever is first takes priority:
 
 ``` clojure
 #?(:org.babashka/nbb 1 :cljs 2) ;;=> 1


### PR DESCRIPTION
Updated the prose to better match the example.  `:org.babashka/nbb` is not prioritized over `:cljs`, rather, whichever comes first is used -- or so it seems to me!

I chose "platform tags" as it is the term used in the [clojure docs](https://clojure.org/guides/reader_conditionals).