### PR TITLE
New bundle --shrinkwrap flag to compile to a single file executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 [Nbb](https://github.com/babashka/nbb): Scripting in Clojure on Node.js using [SCI](https://github.com/babashka/sci)
 
+- [#396](https://github.com/babashka/nbb/issues/396): New `bundle --shrinkwrap` flag to create single file executable
+
 ## 1.3.204 (2025-05-15)
 
 - [#389](https://github.com/babashka/nbb/issues/389): fix regression caused by [#387](https://github.com/babashka/nbb/issues/387)

--- a/README.md
+++ b/README.md
@@ -539,6 +539,12 @@ Running nREPL in Docker container is supported with the optional `:host` argumen
 $ nbb nrepl-server :port 1337 :host 0.0.0.0
 ```
 
+If using [vim-fireplace](https://github.com/tpope/vim-fireplace/) you need to tell it this is a ClojureScript repl:
+
+```
+:CljEval (ns cljs.user)
+```
+
 #### Calva
 
 In Calva connect to the REPL with:

--- a/README.md
+++ b/README.md
@@ -634,7 +634,6 @@ The following projects are using nbb or are supporting it as a development platf
 - [nbb-serverless-example](https://github.com/vharmain/nbb-serverless-example): AWS serverless example using nbb
 - [clojure-quiz](https://github.com/prestancedesign/clojure-quiz): ClojureScript fancy terminal game
 - [monotropic](https://github.com/avelino/monotropic-theme-vscode): Monochromatic light theme for VSCode
-- [devsoutinho/labs](https://github.com/devsoutinho/labs): Flutter universal project + CLJS as backend web framework on top of GraphQL
 - [nbb-logseq](https://github.com/logseq/nbb-logseq): A custom version of nbb with additional features enabled
 - [graph-validator](https://github.com/logseq/graph-validator): Github action to validate logseq notes using nbb-logseq
 - [pg-unused-index-tui](https://github.com/darky/pg-unused-index-tui): TUI for showing unused indexes of Postgres

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "import-meta-resolve": "^4.1.0"
   },
   "devDependencies": {
+    "esbuild": "^0.25.8",
     "ink": "^3.0.9",
     "moment": "^2.29.4",
     "nbb": "file:.",


### PR DESCRIPTION
**Note**: this change introduces `esbuild` as a new dep in devDependencies. If the `esbuild` dependency is a problem, an alternative could be to check for it at runtime instead and tell the user they should install it for this functionality.

---

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/nbb/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/nbb/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [-] This PR contains a [test](https://github.com/babashka/nbb/blob/main/doc/dev.md#tests) to prevent against future regressions
- (no existing bundler tests)

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/nbb/blob/main/CHANGELOG.md) file with a description of the addressed issue.
