### PR TITLE
Add babashka.fs as built-in library, bump babashka.cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 [Nbb](https://github.com/babashka/nbb): Scripting in Clojure on Node.js using [SCI](https://github.com/babashka/sci)
 
+## Unreleased
+
+- Add `babashka.fs` as a built-in library, including the `with-temp-dir` macro
+- Bump `babashka.cli` to 0.12.75
+
 ## 1.4.209 (2026-07-12)
 
 - Bump SCI to 0.14.55. Support implementing CLJS protocols (e.g. `ILookup`, etc) on `deftype` and `defrecord`

--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,8 @@
         com.cognitect/transit-cljs {:mvn/version "0.8.280"}
         #_#_prismatic/schema {:mvn/version "1.3.0"}
         #_#_metosin/malli {:mvn/version "0.8.8"}
-        org.babashka/cli {:mvn/version "0.8.60"}
+        org.babashka/cli {:mvn/version "0.12.75"}
+        babashka/fs {:mvn/version "0.5.34"}
         #_{:local/root "/Users/borkdude/dev/babashka/sci"}
         io.github.babashka/sci.configs #_{:local/root "../sci.configs"}
                                        {:git/url "https://github.com/babashka/sci.configs"

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -46,6 +46,8 @@
                  :depends-on #{:nbb_core}}
     :nbb_tools_cli {:init-fn nbb.impl.tools-cli/init
                     :depends-on #{:nbb_core :nbb_goog_string}}
+    :nbb_fs {:init-fn nbb.impl.fs/init
+             :depends-on #{:nbb_core}}
     :nbb_transit {:init-fn nbb.impl.transit/init
                   :depends-on #{:nbb_core}}
     :nbb_nrepl_server {:init-fn nbb.impl.nrepl-server/init

--- a/src/nbb/impl/fs.cljs
+++ b/src/nbb/impl/fs.cljs
@@ -1,0 +1,39 @@
+(ns nbb.impl.fs
+  {:no-doc true}
+  (:require [babashka.fs]
+            [nbb.core :as nbb]
+            [sci.core :as sci]))
+
+(def fns (sci/create-ns 'babashka.fs nil))
+
+;; babashka.fs/with-temp-dir is a compile-time macro, so copy-ns can't copy it as
+;; a runtime var. Reinterpret it here as an SCI macro that expands to the copied
+;; create-temp-dir / delete-tree vars.
+(defn ^:macro with-temp-dir
+  "Evaluates body with `temp-dir` bound to the result of `(create-temp-dir opts)`.
+
+  By default, the `temp-dir` will be removed with `delete-tree` on exit from the
+  scope.
+
+  Options:
+  * see `create-temp-dir` for options that control directory creation
+  * `:keep` - if `true` does not delete the directory on exit from macro scope."
+  [_ _ [temp-dir opts & more] & body]
+  (assert (empty? more) "with-temp-dir binding takes at most 2 forms")
+  (assert (symbol? temp-dir) "with-temp-dir needs a symbol to bind")
+  `(let [opts# ~opts
+         ~temp-dir (babashka.fs/create-temp-dir opts#)]
+     (try
+       ~@body
+       (finally
+         (when-not (:keep opts#)
+           (babashka.fs/delete-tree ~temp-dir {:force true}))))))
+
+(def fs-namespace
+  (assoc (sci/copy-ns babashka.fs fns {:exclude [with-temp-dir]})
+         'with-temp-dir (sci/copy-var with-temp-dir fns)))
+
+(defn init []
+  (nbb/register-plugin!
+   ::fs
+   {:namespaces {'babashka.fs fs-namespace}}))

--- a/src/nbb/macros.clj
+++ b/src/nbb/macros.clj
@@ -39,6 +39,7 @@
                        clojure.test "./nbb_test.js"
                        nbb.repl "./nbb_repl.js"
                        clojure.tools.cli "./nbb_tools_cli.js"
+                       babashka.fs "./nbb_fs.js"
                        goog.string "./nbb_goog_string.js"
                        goog.string.format "./nbb_goog_string.js"
                        goog.crypt "./nbb_goog_crypt.js"

--- a/test/nbb/main_test.cljs
+++ b/test/nbb/main_test.cljs
@@ -109,6 +109,22 @@
       (.then (fn [v]
                (is (= :hello v))))))
 
+(deftest-async babashka-fs-test
+  (-> (nbb/load-string "(require '[babashka.fs :as bfs])
+                        [(bfs/exists? \"deps.edn\") (bfs/file-name \"/a/b.txt\")]")
+      (.then (fn [v]
+               (is (= [true "b.txt"] v))))))
+
+(deftest-async babashka-fs-with-temp-dir-test
+  (-> (nbb/load-string "(require '[babashka.fs :as bfs])
+                        (let [captured (atom nil)]
+                          (bfs/with-temp-dir [d]
+                            (reset! captured (str d))
+                            {:inside (bfs/exists? d)})
+                          {:inside true :after (bfs/exists? @captured)})")
+      (.then (fn [v]
+               (is (= {:inside true :after false} v))))))
+
 (deftest-async as-alias
   (-> (nbb/load-string "(require '[rando.ns :as-alias dude]) ::dude/foo")
       (.then (fn [v]


### PR DESCRIPTION
babashka.fs compiles to CLJS/Node via reader conditionals. Register it as a lazily-loaded module (nbb_fs), copying its public vars into SCI. Its with-temp-dir macro is a compile-time macro that copy-ns cannot copy as a runtime var, so reinterpret it as an SCI macro over create-temp-dir and delete-tree.

Bump babashka.cli 0.8.60 -> 0.12.75.

